### PR TITLE
Siil french translations

### DIFF
--- a/modules/openlmis-web/src/main/resources/messages_fr.properties
+++ b/modules/openlmis-web/src/main/resources/messages_fr.properties
@@ -751,7 +751,7 @@ error.select.program = Sélectionnez un programme s'il vous plait
 error.select.roles = Sélectionnez des rôles s'il vous plait
 error.delivery.zone.program.combination = Combinaison de zone et programme déjà sélectionnée
 msg.roles.delivery.zone.deletion = Tous les rôles assignés à cette commune de livraison pour l'utilisateur seront supprimés
-label.total = Totale
+label.total = Total
 button.initiate.distribution = Démarrer distribution
 label.initiated.distributions = Distributions déjà lancées
 
@@ -1104,6 +1104,7 @@ label.child.coverage.second.total = Total
 label.child.coverage.total.vaccination = Total de la population vaccinée
 label.coverage.opened.vials = Flacons ouverts
 label.coverage.opened.vials.wastage.rate = Taux de perte en flacons overts
+label.adult.opened.vials.wastage.rate = Taux de perte en unités de flacon overt
 label.was.facility.visited = Le {0} a-t-il été visité en {1}?
 label.was.stockouts = Avez-vous connu une rupture de stock depuis la dernière visite ?
 label.stockouts.select = Si oui, quelle était la raison de la rupture ? (Cochez toutes les causes appropriées)
@@ -1161,7 +1162,7 @@ error.cost.negative = Le cout d'envoi ne peut pas être négatif
 invalid.quantity.shipped = La quantité envoyée ne peut pas être composée de plus que 08 caractères
 
 label.coverage.adult = Couverture VAT
-label.adult.group.vaccinations = Vaccinations de VAT en groupe (doses)
+label.adult.group.vaccinations = Doses de VAT administrées à la population cible VAT (en doses)
 label.coverage.pregnant.women = Femmes enceintes
 label.coverage.mif = Femmes de 15-49 ans
 label.coverage.community = Communauté
@@ -1174,9 +1175,9 @@ label.coverage.other.not.mif = Autres sauf femmes de 15-49 ans
 error.invalid.returned.quantity = Quantité retournée non valide
 header.quantity.returned = Quantité Retourné
 
-label.adult.tetanus.first = 1ere dose de VAT
-label.adult.tetanus.second.fifth = 2eme - 5eme dose de VAT
-label.total.tetanus = Totale de VAT
+label.adult.tetanus.first = 1ère dose de VAT
+label.adult.tetanus.second.fifth = 2ème – 5ème doses de VAT
+label.total.tetanus = Total de la population vaccinée en VAT
 
 label.receivedBy = Reçu par
 label.deliveredBy = Livré par

--- a/modules/openlmis-web/src/main/resources/messages_fr.properties
+++ b/modules/openlmis-web/src/main/resources/messages_fr.properties
@@ -1067,7 +1067,7 @@ label.non.full.supply=Approvisionnement non complet
 msg.budget.not.allocated = Non alloué
 msg.cost.exceeds.budget = Le coût total dépasse le budget alloué
 
-label.doses.unit = Vaccins et Intrants: saisir les données en unités de flacons
+label.doses.unit = Vaccins et intrants: saisir les données en unités de doses
 label.ideal.quantity = Stock Maximum
 label.existing.quantity = Quantité Disponible (en doses)
 label.delivered.quantity = Quantité Livrée (en doses)

--- a/modules/openlmis-web/src/main/webapp/public/pages/logistics/distribution/partials/adult-coverage.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/logistics/distribution/partials/adult-coverage.html
@@ -35,7 +35,7 @@
   <th id="totalTetanusLabel" openlmis-message="label.total.tetanus" rowspan="2"></th>
   <th id="coverageRateLabel" openlmis-message="label.coverage.rate" rowspan="2"></th>
   <th id="openedVialsLabel" openlmis-message="label.coverage.opened.vials" rowspan="2"></th>
-  <th id="wastageRateLabel" openlmis-message="label.coverage.opened.vials.wastage.rate" rowspan="2"></th>
+  <th id="wastageRateLabel" openlmis-message="label.adult.opened.vials.wastage.rate" rowspan="2"></th>
 </tr>
 <tr>
   <th id="healthCenter1Label" openlmis-message="label.coverage.health.center"></th>


### PR DESCRIPTION
Added new French translations for Adult Coverage screen, as well as fixing the typo in one of the existing translation in EPI Inventory screen. These French translations were the only remaining ones which were not done along with other changes.
